### PR TITLE
Add global challenge functionality

### DIFF
--- a/src/main/java/com/cs98/VerbatimBackend/VerbatimBackendApplication.java
+++ b/src/main/java/com/cs98/VerbatimBackend/VerbatimBackendApplication.java
@@ -2,7 +2,9 @@ package com.cs98.VerbatimBackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class VerbatimBackendApplication {
 

--- a/src/main/java/com/cs98/VerbatimBackend/controller/AuthenticationController.java
+++ b/src/main/java/com/cs98/VerbatimBackend/controller/AuthenticationController.java
@@ -18,13 +18,18 @@ public class AuthenticationController {
     private UserRepository userRepository;
     @PostMapping(path = "api/v1/register")
     public ResponseEntity<User> register(@RequestBody RegisterRequest request) {
-        if (userRepository.existsByUsername(request.getUsername()) || userRepository.existsByEmail(request.getEmail())) {
+        if (userRepository.existsByEmail(request.getEmail()) || userRepository.existsByUsername(request.getUsername())) {
             return ResponseEntity.badRequest().build();
         }
         User newUser = User.builder()
-                .username(request.getUsername())
+                .firstName(request.getFirstName())
+                .lastName(request.getLastName())
                 .email(request.getEmail())
+                .username(request.getUsername())
                 .password(request.getPassword())
+                .numGlobalChallengesCompleted(0)
+                .numCustomChallengesCompleted(0)
+                .streak(0)
                 .build();
 
         return ResponseEntity.ok(userRepository.save(newUser));

--- a/src/main/java/com/cs98/VerbatimBackend/controller/GlobalChallengeController.java
+++ b/src/main/java/com/cs98/VerbatimBackend/controller/GlobalChallengeController.java
@@ -1,0 +1,21 @@
+package com.cs98.VerbatimBackend.controller;
+
+import com.cs98.VerbatimBackend.model.GlobalChallenge;
+import com.cs98.VerbatimBackend.repository.GlobalChallengeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GlobalChallengeController {
+
+    @Autowired
+    private GlobalChallengeRepository globalChallengeRepository;
+
+    @GetMapping(path = "api/v1/globalChallenge")
+    public ResponseEntity<GlobalChallenge> getDailyChallenge() {
+        GlobalChallenge dailyChallenge = globalChallengeRepository.findFirst1ByOrderByDateDesc();
+        return ResponseEntity.ok(dailyChallenge);
+    }
+}

--- a/src/main/java/com/cs98/VerbatimBackend/model/Category.java
+++ b/src/main/java/com/cs98/VerbatimBackend/model/Category.java
@@ -1,0 +1,26 @@
+package com.cs98.VerbatimBackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "category")
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    private String title;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Question> question;
+}

--- a/src/main/java/com/cs98/VerbatimBackend/model/GlobalChallenge.java
+++ b/src/main/java/com/cs98/VerbatimBackend/model/GlobalChallenge.java
@@ -1,0 +1,32 @@
+package com.cs98.VerbatimBackend.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Date;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GlobalChallenge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    private String q1;
+
+    private String q2;
+
+    private String q3;
+
+    private Date date;
+}

--- a/src/main/java/com/cs98/VerbatimBackend/model/Question.java
+++ b/src/main/java/com/cs98/VerbatimBackend/model/Question.java
@@ -1,0 +1,26 @@
+package com.cs98.VerbatimBackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "question")
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+}

--- a/src/main/java/com/cs98/VerbatimBackend/model/User.java
+++ b/src/main/java/com/cs98/VerbatimBackend/model/User.java
@@ -1,8 +1,15 @@
 package com.cs98.VerbatimBackend.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
 import org.antlr.v4.runtime.misc.NotNull;
+import org.hibernate.annotations.Where;
+import org.springframework.util.CollectionUtils;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Builder
 @AllArgsConstructor
@@ -21,6 +28,21 @@ public class User {
     @Column(unique = true)
     private String username;
 
+    private String firstName;
+
+    private String lastName;
+
     private String password;
+
+    private String profilePicture;
+
+    private String bio;
+
+    private Integer numGlobalChallengesCompleted;
+
+    private Integer numCustomChallengesCompleted;
+
+    private Integer streak;
+
 
 }

--- a/src/main/java/com/cs98/VerbatimBackend/repository/CategoryRepository.java
+++ b/src/main/java/com/cs98/VerbatimBackend/repository/CategoryRepository.java
@@ -1,0 +1,15 @@
+package com.cs98.VerbatimBackend.repository;
+
+import com.cs98.VerbatimBackend.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Integer> {
+
+    @Query(value = "SELECT * FROM category ORDER BY RANDOM() LIMIT 3", nativeQuery = true)
+    List<Category> fetchThreeRandomCategories();
+}

--- a/src/main/java/com/cs98/VerbatimBackend/repository/GlobalChallengeRepository.java
+++ b/src/main/java/com/cs98/VerbatimBackend/repository/GlobalChallengeRepository.java
@@ -1,0 +1,9 @@
+package com.cs98.VerbatimBackend.repository;
+
+import com.cs98.VerbatimBackend.model.GlobalChallenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GlobalChallengeRepository extends JpaRepository<GlobalChallenge, Integer> {
+
+    GlobalChallenge findFirst1ByOrderByDateDesc();
+}

--- a/src/main/java/com/cs98/VerbatimBackend/repository/QuestionRepository.java
+++ b/src/main/java/com/cs98/VerbatimBackend/repository/QuestionRepository.java
@@ -1,0 +1,14 @@
+package com.cs98.VerbatimBackend.repository;
+
+import com.cs98.VerbatimBackend.model.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Integer> {
+
+    @Query(value = "SELECT * FROM question WHERE category_id = ?1 ORDER BY RANDOM() LIMIT 1", nativeQuery = true)
+    Question fetchRandomQuestionByCategoryId(Integer categoryId);
+
+}

--- a/src/main/java/com/cs98/VerbatimBackend/repository/UserRepository.java
+++ b/src/main/java/com/cs98/VerbatimBackend/repository/UserRepository.java
@@ -7,11 +7,11 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
 
-    Boolean existsByUsername(String username);
-
-    User findByUsername(String username);
-
     Boolean existsByEmail(String email);
 
     User findByEmail(String email);
+
+    User findByUsername(String username);
+
+    Boolean existsByUsername(String username);
 }

--- a/src/main/java/com/cs98/VerbatimBackend/request/RegisterRequest.java
+++ b/src/main/java/com/cs98/VerbatimBackend/request/RegisterRequest.java
@@ -4,6 +4,10 @@ import lombok.Data;
 
 @Data
 public class RegisterRequest {
+    private String firstName;
+
+    private String lastName;
+
     private String username;
 
     private String email;

--- a/src/main/java/com/cs98/VerbatimBackend/schedule/GlobalChallengeGenerator.java
+++ b/src/main/java/com/cs98/VerbatimBackend/schedule/GlobalChallengeGenerator.java
@@ -1,0 +1,48 @@
+package com.cs98.VerbatimBackend.schedule;
+
+import com.cs98.VerbatimBackend.model.Category;
+import com.cs98.VerbatimBackend.model.GlobalChallenge;
+import com.cs98.VerbatimBackend.model.Question;
+import com.cs98.VerbatimBackend.repository.CategoryRepository;
+import com.cs98.VerbatimBackend.repository.GlobalChallengeRepository;
+import com.cs98.VerbatimBackend.repository.QuestionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class GlobalChallengeGenerator {
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private GlobalChallengeRepository globalChallengeRepository;
+
+    @Scheduled(fixedRate = 30000)
+    public void createDailyChallenge() {
+        List<Category> dailyCategories = categoryRepository.fetchThreeRandomCategories();
+        List<Question> dailyQuestions = new ArrayList<>();
+        for (Category category : dailyCategories) {
+            Question question = questionRepository.fetchRandomQuestionByCategoryId(category.getId());
+            dailyQuestions.add(question);
+        }
+
+        GlobalChallenge globalChallenge = GlobalChallenge.builder()
+                .date(Date.valueOf(LocalDate.now()))
+                .q1(dailyQuestions.get(0).getContent())
+                .q2(dailyQuestions.get(1).getContent())
+                .q3(dailyQuestions.get(2).getContent())
+                .build();
+
+        globalChallengeRepository.save(globalChallenge);
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,9 +1,11 @@
 
 
 hostUrl=http://localhost:3000
-
+spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true
 spring.datasource.url=jdbc:postgresql://localhost:5432/verbatim
 # spring.datasource.username= <your local postgres username>
 # spring.datasource.password= <your local postgres password>
-spring.jpa.hibernate.ddl-auto=create-drop
+
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,30 @@
+insert into category (id, title) values (1, 'Sports');
+insert into category (id, title) values (2, 'Animals');
+insert into category (id, title) values (3, 'Fruits');
+
+insert into question (id, content, category_id) values (1, 'Sports that Start with T', 1);
+insert into question (id, content, category_id) values (2, 'Sports that Start With B', 1);
+insert into question (id, content, category_id) values (3, 'Famous Basketball Players', 1);
+insert into question (id, content, category_id) values (4, 'Famous Football Players', 1);
+insert into question (id, content, category_id) values (5, 'Sports Without Balls', 1);
+
+insert into question (id, content, category_id) values (6, 'Animals that Live Underwater', 2);
+insert into question (id, content, category_id) values (7, 'Cat Breeds', 2);
+insert into question (id, content, category_id) values (8, 'Dog Breeds', 2);
+insert into question (id, content, category_id) values (9, 'Spotted Animals', 2);
+insert into question (id, content, category_id) values (10, 'Flightless Birds', 2);
+
+insert into question (id, content, category_id) values (11, 'Yellow Fruits', 3);
+insert into question (id, content, category_id) values (12, 'Types of Apples', 3);
+insert into question (id, content, category_id) values (13, 'Fruits with Two Syllables', 3);
+insert into question (id, content, category_id) values (14, 'Fruits that Start With C', 3);
+insert into question (id, content, category_id) values (15, 'Fruits that Start With L', 3);
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Added the additional fields we discussed to the user model and also added global challenge generation. The file 'data.sql' is a script that will run on startup that inserts some categories and questions that I came up with. The GlobalChallengeGenerator class pulls three random categories from the db, selects a random question for each category, then saves those questions as a new daily challenge. For testing purposes, I configured it to generate a new global challenge every 30 seconds, but if you want to change this just modify the 'fixedRate' argument to whatever you want. The endpoint 'api/v1/globalChallenge' will fetch the most recently generated global challenge from the database. Frontend should call that endpoint to get the questions to display on the screen. 